### PR TITLE
Fixed update and edit profile buttons for Profile Page

### DIFF
--- a/Reactapp/react_app/src/pages/Profile.tsx
+++ b/Reactapp/react_app/src/pages/Profile.tsx
@@ -1,7 +1,53 @@
+import { useState, useEffect } from "react";
 import "../styles/pages/Profile_Page.css";
 import Navbar from "../components/Navbar";
 
 const Profile = () => {
+  // State to store user input
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [notification, setNotification] = useState("");
+  const [isEditing, setIsEditing] = useState(false); // Controls edit mode
+  const [isClicked, setIsClicked] = useState(""); // Tracks clicked button
+
+  // Load saved data from localStorage on component mount
+  useEffect(() => {
+    const savedUsername = localStorage.getItem("username");
+    const savedEmail = localStorage.getItem("email");
+
+    if (savedUsername) setUsername(savedUsername);
+    if (savedEmail) setEmail(savedEmail);
+  }, []);
+
+  // Enable editing when "EDIT PROFILE" is clicked
+  const handleEdit = () => {
+    setIsEditing(true);
+    setIsClicked("edit");
+    setTimeout(() => setIsClicked(""), 200); // Remove effect after 200ms
+  };
+
+  // Handle form update and save to localStorage
+  const handleUpdate = () => {
+    localStorage.setItem("username", username);
+    localStorage.setItem("email", email);
+
+    // Set notification message
+    setNotification("Changes saved successfully!");
+
+    // Disable editing after saving
+    setIsEditing(false);
+
+    // Click effect
+    setIsClicked("update");
+    setTimeout(() => setIsClicked(""), 200);
+
+    // Hide notification after 3 seconds
+    setTimeout(() => {
+      setNotification("");
+    }, 3000);
+  };
+
   return (
     <div className="profile-page">
       <div className="background-image"></div>
@@ -13,20 +59,56 @@ const Profile = () => {
             <div className="profile-icon">
               <i className="fa fa-user"></i>
             </div>
-            <button className="edit-profile-button">EDIT PROFILE</button>
+
+            {/* Edit Profile Button */}
+            <button 
+              className={`edit-profile-button ${isClicked === "edit" ? "clicked" : ""}`} 
+              onClick={handleEdit}
+            >
+              EDIT PROFILE
+            </button>
 
             {/* User fields */}
-            <form className="profile-form">
+            <form className="profile-form" onSubmit={(e) => e.preventDefault()}>
               <label>USERNAME</label>
-              <input type="text" placeholder="USERNAME" />
+              <input 
+                type="text" 
+                value={username} 
+                onChange={(e) => setUsername(e.target.value)} 
+                placeholder="USERNAME" 
+                disabled={!isEditing} // Disabled unless editing
+              />
 
               <label>EMAIL</label>
-              <input type="email" placeholder="EMAIL" />
+              <input 
+                type="email" 
+                value={email} 
+                onChange={(e) => setEmail(e.target.value)} 
+                placeholder="EMAIL" 
+                disabled={!isEditing} // Disabled unless editing
+              />
 
               <label>PASSWORD</label>
-              <input type="password" placeholder="PASSWORD" />
+              <input 
+                type="password" 
+                value={password} 
+                onChange={(e) => setPassword(e.target.value)} 
+                placeholder="PASSWORD" 
+                disabled={!isEditing} // Disabled unless editing
+              />
 
-              <button type="button" className="update-button">UPDATE</button>
+              {/* Update Button */}
+              <button 
+                type="button" 
+                className={`update-button ${isClicked === "update" ? "clicked" : ""}`} 
+                onClick={handleUpdate}
+                disabled={!isEditing} // Prevents clicking "UPDATE" before editing
+              >
+                UPDATE
+              </button>
+
+              {/* Notification */}
+              {notification && <p className="notification">{notification}</p>}
             </form>
           </div>
         </div>

--- a/Reactapp/react_app/src/styles/pages/Profile_Page.css
+++ b/Reactapp/react_app/src/styles/pages/Profile_Page.css
@@ -111,4 +111,16 @@
     margin-top: 20px; 
     font-size: 1rem;
   }
+
+    /* Hover effect */
+  .edit-profile-button:hover, .update-button:hover {
+    transform: scale(1.05);
+  }
+
+  /* Clicked effect */
+  .clicked {
+    filter: brightness(0.8); /* Darkens the button */
+    transform: scale(0.95);
+    transition: all 0.1s ease-in-out;
+  }
   


### PR DESCRIPTION
Updated the Profile Page to allow users to edit their email and password fields only after clicking "Edit Profile" and save them when clicking "Update". Also enhanced button interactions by adding a hover effect (enlargement) and a click effect (darkening and shrinking).